### PR TITLE
change way of contacting the buffer

### DIFF
--- a/color.rb
+++ b/color.rb
@@ -16,7 +16,7 @@ module Color
         end
 
         def write ( entry )
-            @buffer += entry.to_json + "\n"
+            @buffer << entry.to_json << "\n".freeze
             if @buffer.size >= 60000
                 flush() # auto-flush
             end


### PR DESCRIPTION
I did a small benchmark on ruby 2.3 of using +, << and concat() to see if it has any performance differences.
Running 10k loop of adding to an empty string 400 chars and these are the results:

```

 user     system      total        real
concat:   0.000000   0.000000   0.000000 (  0.011829)
+:       10.350000   9.330000  19.680000 ( 19.800366)
<<:       0.010000   0.000000   0.010000 (  0.003826)
```

As you see using << is much faster and with good reason:
+ operator will create a new array each time it is called (which is expensive), while concat and << only appends the new element.

The .freeze is only available after ruby 2.3 but it will remove the need to allocate memory every time the function write is called for the "\n". You can add freeze if you want to all the string (not major impact)

code for benchmark (with shorter strings)
```
Benchmark.bm(7) do |x|
  x.report("concat:") { amount.times do   ; a.concat('something'); end }
  x.report("+:")      { amount.times do   ; b += 'something'; end }
  x.report("<<:")     { amount.times do   ; d << 'something'; end }
end
```